### PR TITLE
Adjust checkbox color scheme

### DIFF
--- a/src/checkbox.css
+++ b/src/checkbox.css
@@ -7,8 +7,8 @@
   display: inline-block;
   width: 1.2rem;
   height: 1.1rem;
-  background-color: #111;
-  border: 1px solid #eee;
+  background-color: #fff;
+  border: 1px solid #ccc;
   border-radius: 0.25rem;
   cursor: pointer;
   position: relative;
@@ -43,8 +43,8 @@
   display: inline-block;
   width: 1.2rem;
   height: 1.1rem;
-  background-color: #111;
-  border: 1px solid #555;
+  background-color: #fff;
+  border: 1px solid #ccc;
   border-radius: 0.25rem;
   cursor: pointer;
   position: relative;
@@ -79,8 +79,8 @@
   display: inline-block;
   width: 1.2rem;
   height: 1.1rem;
-  background-color: #111;
-  border: 1px solid #555;
+  background-color: #fff;
+  border: 1px solid #ccc;
   border-radius: 0.25rem;
   cursor: pointer;
   position: relative;


### PR DESCRIPTION
## Summary
- lighten backgrounds for today, day and past day checkboxes
- use light gray borders to keep visibility on a bright background

## Testing
- `npm run lint` *(fails: prop-types errors)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843369f4134832498ffb4103b022997